### PR TITLE
fix: wire download-db.sh into Vercel build command

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+scripts/*
+!scripts/download-db.sh
+data/seed
+data/database-premium.db
+data/source

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm run build",
+  "buildCommand": "bash scripts/download-db.sh && npm run build",
   "outputDirectory": ".",
   "functions": {
     "api/mcp.ts": {


### PR DESCRIPTION
## Summary
- Updates `vercel.json` buildCommand to `bash scripts/download-db.sh && npm run build` (script already existed)
- Adds `.vercelignore` to exclude large ingestion scripts and seed data while allowing `download-db.sh` through

## Root cause
Vercel deployments returned HTTP 500 because `data/database.db` was missing — the premium DB is too large for Vercel. The `download-db.sh` script existed but was not wired into the build command.

## Fix
The free-tier DB (122 MB uncompressed, 50 MB gzipped) has been uploaded to the v1.2.3 GitHub Release. The build command now downloads and gunzips it before running `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)