### PR TITLE
docs: fix remote endpoint URL to use ISO code path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ This MCP server makes Swedish law **searchable, cross-referenceable, and AI-read
 
 > Connect directly to the hosted version — zero dependencies, nothing to install.
 
-**Endpoint:** `https://mcp.ansvar.eu/law-swedish-law-mcp/mcp`
+**Endpoint:** `https://mcp.ansvar.eu/law-se/mcp`
 
 | Client | How to Connect |
 |--------|---------------|
 | **Claude.ai** | Settings > Connectors > Add Integration > paste URL |
-| **Claude Code** | `claude mcp add swedish-law --transport http https://mcp.ansvar.eu/law-swedish-law-mcp/mcp` |
+| **Claude Code** | `claude mcp add swedish-law --transport http https://mcp.ansvar.eu/law-se/mcp` |
 | **Claude Desktop** | Add to config (see below) |
 | **GitHub Copilot** | Add to VS Code settings (see below) |
 
@@ -55,7 +55,7 @@ This MCP server makes Swedish law **searchable, cross-referenceable, and AI-read
   "mcpServers": {
     "swedish-law": {
       "type": "url",
-      "url": "https://mcp.ansvar.eu/law-swedish-law-mcp/mcp"
+      "url": "https://mcp.ansvar.eu/law-se/mcp"
     }
   }
 }
@@ -68,7 +68,7 @@ This MCP server makes Swedish law **searchable, cross-referenceable, and AI-read
   "github.copilot.chat.mcp.servers": {
     "swedish-law": {
       "type": "http",
-      "url": "https://mcp.ansvar.eu/law-swedish-law-mcp/mcp"
+      "url": "https://mcp.ansvar.eu/law-se/mcp"
     }
   }
 }

--- a/server.json
+++ b/server.json
@@ -36,7 +36,7 @@
       "version": "1.2.2",
       "transport": {
         "type": "streamable-http",
-        "url": "https://mcp.ansvar.eu/law-swedish-law-mcp/mcp"
+        "url": "https://mcp.ansvar.eu/law-se/mcp"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Fix `mcp.ansvar.eu` URL from `/law-swedish-law-mcp/` (404) to `/law-se/` (working)
- The nginx proxy on `mcp.ansvar.eu` uses ISO country code paths, not descriptive names
- Affects README.md (4 occurrences) and server.json (1 occurrence)

Part of a fleet-wide fix — 119 law MCP repos have wrong endpoint URLs.