### PR TITLE
feat: add _citation metadata for deterministic citations

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+scripts/*
+!scripts/download-db.sh
+data/seed
+data/database-premium.db
+data/source

--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -5,6 +5,7 @@
 import type { Database } from '@ansvar/mcp-sqlite';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
+import { buildProvisionCitation } from '../utils/citation.js';
 
 export interface GetProvisionInput {
   document_id: string;
@@ -39,6 +40,8 @@ interface ProvisionRow {
   document_id: string;
   document_title: string;
   document_status: string;
+  document_url: string | null;
+  document_short_name: string | null;
   provision_ref: string;
   chapter: string | null;
   section: string;
@@ -88,6 +91,8 @@ export async function getProvision(
         lpv.document_id,
         ld.title as document_title,
         ld.status as document_status,
+        ld.url as document_url,
+        ld.short_name as document_short_name,
         lpv.provision_ref,
         lpv.chapter,
         lpv.section,
@@ -112,6 +117,8 @@ export async function getProvision(
         lp.document_id,
         ld.title as document_title,
         ld.status as document_status,
+        ld.url as document_url,
+        ld.short_name as document_short_name,
         lp.provision_ref,
         lp.chapter,
         lp.section,
@@ -146,7 +153,16 @@ export async function getProvision(
       metadata: row.metadata ? JSON.parse(row.metadata) : null,
       cross_references: crossRefs,
     },
-    _metadata: generateResponseMetadata(db)
+    _metadata: generateResponseMetadata(db),
+    _citation: buildProvisionCitation(
+      row.document_id,
+      row.document_title,
+      row.provision_ref,
+      input.document_id,
+      provisionRef,
+      row.document_url,
+      row.document_short_name,
+    ),
   };
 }
 

--- a/src/utils/citation.ts
+++ b/src/utils/citation.ts
@@ -1,0 +1,70 @@
+/**
+ * Citation metadata for the deterministic citation pipeline.
+ *
+ * Provides structured identifiers (canonical_ref, display_text, aliases)
+ * that the platform's entity linker uses to match references in agent
+ * responses to MCP tool results — without relying on LLM formatting.
+ *
+ * See: docs/guides/law-mcp-golden-standard.md Section 4.9c
+ */
+
+export interface CitationMetadata {
+  canonical_ref: string;
+  display_text: string;
+  aliases?: string[];
+  source_url?: string;
+  lookup: {
+    tool: string;
+    args: Record<string, string>;
+  };
+}
+
+/**
+ * Build citation metadata for a get_provision response.
+ *
+ * @param documentId     DB identifier (e.g., "2018:218")
+ * @param documentTitle  Human-readable law title (e.g., "Lag med kompletterande bestämmelser...")
+ * @param provisionRef   Provision reference (e.g., "34" or "3:12")
+ * @param inputDocId     The document_id argument as passed by the caller (e.g., "sfs-2018-218")
+ * @param inputSection   The section argument as passed by the caller (e.g., "art-34")
+ * @param sourceUrl      Official portal URL for this law (optional)
+ * @param shortName      Short name / alias (e.g., "DSL") (optional)
+ */
+export function buildProvisionCitation(
+  documentId: string,
+  documentTitle: string,
+  provisionRef: string,
+  inputDocId: string,
+  inputSection: string,
+  sourceUrl?: string | null,
+  shortName?: string | null,
+): CitationMetadata {
+  // Build canonical_ref from the SFS number format
+  // DB id "2018:218" -> "SFS 2018:218" (Swedish statute format)
+  const canonicalRef = documentId.match(/^\d{4}:\d+$/)
+    ? `SFS ${documentId}`
+    : documentTitle;
+
+  // Build display_text
+  const sectionLabel = provisionRef.includes(':')
+    ? `${provisionRef.split(':')[0]} kap. ${provisionRef.split(':')[1]} §`
+    : `${provisionRef} §`;
+  const displayText = `${sectionLabel} ${canonicalRef}`;
+
+  // Build aliases from document title and short name
+  const aliases: string[] = [];
+  if (shortName) aliases.push(shortName);
+  // Add the raw document_id as an alias (matches argument-derived patterns)
+  if (documentId !== canonicalRef) aliases.push(documentId);
+
+  return {
+    canonical_ref: canonicalRef,
+    display_text: displayText,
+    ...(aliases.length > 0 && { aliases }),
+    ...(sourceUrl && { source_url: sourceUrl }),
+    lookup: {
+      tool: 'get_provision',
+      args: { document_id: inputDocId, section: inputSection },
+    },
+  };
+}

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -181,4 +181,11 @@ export interface ToolResponse<T> {
 
   /** Professional-use metadata and warnings */
   _metadata: ResponseMetadata;
+
+  /** Citation metadata for deterministic citation pipeline (optional) */
+  _citation?: import('./citation.js').CitationMetadata;
+
+  /** Truncation hint (optional) */
+  _truncated?: boolean;
+  _hint?: string;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
     "api/mcp.ts": {
       "maxDuration": 30,
       "memory": 1024,
-      "includeFiles": "{data/database.db,node_modules/.pnpm/node-sqlite3-wasm*/node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm}"
+      "includeFiles": "{data/database.db,node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm}"
     }
   },
   "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,11 @@
       "maxDuration": 30,
       "memory": 1024,
       "includeFiles": "{data/database.db,node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm,node_modules/.pnpm/node-sqlite3-wasm*/node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm}"
+    },
+    "api/health.ts": {
+      "maxDuration": 30,
+      "memory": 1024,
+      "includeFiles": "{data/database.db,node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm,node_modules/.pnpm/node-sqlite3-wasm*/node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm}"
     }
   },
   "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm run build",
+  "buildCommand": "bash scripts/download-db.sh && npm run build",
   "outputDirectory": ".",
   "functions": {
     "api/mcp.ts": {

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
     "api/mcp.ts": {
       "maxDuration": 30,
       "memory": 1024,
-      "includeFiles": "{data/database.db,node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm}"
+      "includeFiles": "{data/database.db,node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm,node_modules/.pnpm/node-sqlite3-wasm*/node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm}"
     }
   },
   "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "bash scripts/download-db.sh && npm run build",
+  "buildCommand": "bash scripts/download-db.sh \"\" --force && npm run build",
   "outputDirectory": ".",
   "functions": {
     "api/mcp.ts": {
@@ -10,8 +10,17 @@
     }
   },
   "rewrites": [
-    { "source": "/mcp", "destination": "/api/mcp" },
-    { "source": "/health", "destination": "/api/health" },
-    { "source": "/version", "destination": "/api/health?version" }
+    {
+      "source": "/mcp",
+      "destination": "/api/mcp"
+    },
+    {
+      "source": "/health",
+      "destination": "/api/health"
+    },
+    {
+      "source": "/version",
+      "destination": "/api/health?version"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `src/utils/citation.ts` — `buildProvisionCitation()` helper
- Patches `get-provision.ts` — includes `_citation` in response with `canonical_ref`, `display_text`, `aliases`, `source_url`, and `lookup`
- Extends `ToolResponse` type to support `_citation` field

## What this enables

The platform's entity linker matches references in agent responses (e.g., "SFS 2018:218") to MCP tool results using `_citation` metadata. Without it, the linker has to guess by de-slugifying argument values — which is fragile and misses aliases.

## Example output

```json
{
  "_citation": {
    "canonical_ref": "SFS 2018:218",
    "display_text": "34 § SFS 2018:218",
    "aliases": ["DSL"],
    "source_url": "https://riksdagen.se/...",
    "lookup": { "tool": "get_provision", "args": { "document_id": "sfs-2018-218", "section": "34" } }
  }
}
```

## Test plan

- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Deploy to dev, query Swedish Compliance Expert
- [ ] Verify cite:// links appear on SFS references in response
- [ ] Verify premium tool responses also include _citation

🤖 Generated with [Claude Code](https://claude.com/claude-code)