### PR TITLE
Sync dev to main: case-law search JOIN fix + accumulated dev work

### DIFF
--- a/src/tools/build-legal-stance.ts
+++ b/src/tools/build-legal-stance.ts
@@ -209,14 +209,14 @@ export async function buildLegalStance(
     let clSql = `
       SELECT
         cl.document_id,
-        ld.title,
+        COALESCE(ld.title, cl.case_number, cl.document_id) as title,
         cl.court,
         cl.decision_date,
         snippet(case_law_fts, 0, '>>>', '<<<', '...', 32) as summary_snippet,
         bm25(case_law_fts) as relevance
       FROM case_law_fts
       JOIN case_law cl ON cl.id = case_law_fts.rowid
-      JOIN legal_documents ld ON ld.id = cl.document_id
+      LEFT JOIN legal_documents ld ON ld.id = cl.document_id
       WHERE case_law_fts MATCH ?
     `;
     const clParams: (string | number)[] = [];

--- a/src/tools/search-case-law.ts
+++ b/src/tools/search-case-law.ts
@@ -46,10 +46,14 @@ export async function searchCaseLaw(
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
   const queryVariants = buildFtsQueryVariants(input.query);
 
+  // LEFT JOIN: production case_law rows often have document_id values
+  // (e.g. "NJA_2020_s45") that are not present in legal_documents. An
+  // INNER JOIN drops every such row and silently returns empty results.
+  // Title falls back to case_number or document_id when no link exists.
   let sql = `
     SELECT
       cl.document_id,
-      ld.title,
+      COALESCE(ld.title, cl.case_number, cl.document_id) as title,
       cl.court,
       cl.case_number,
       cl.decision_date,
@@ -58,7 +62,7 @@ export async function searchCaseLaw(
       bm25(case_law_fts) as relevance
     FROM case_law_fts
     JOIN case_law cl ON cl.id = case_law_fts.rowid
-    JOIN legal_documents ld ON ld.id = cl.document_id
+    LEFT JOIN legal_documents ld ON ld.id = cl.document_id
     WHERE case_law_fts MATCH ?
   `;
 

--- a/tests/tools/search-case-law.test.ts
+++ b/tests/tools/search-case-law.test.ts
@@ -69,4 +69,33 @@ describe('search_case_law', () => {
       expect(result._metadata.attribution).toContain('CC-BY Domstolsverket');
     }
   });
+
+  // Regression: production case_law rows often have document_id values
+  // (e.g. "NJA_2020_s45") that do not appear in legal_documents. The
+  // INNER JOIN previously dropped every such row, returning empty results
+  // for every query against the live premium DB even though FTS matched
+  // hundreds of cases. Search must surface these rows; title falls back
+  // to case_number or document_id when no legal_document is linked.
+  it('should return case_law rows whose document_id is not in legal_documents', async () => {
+    db.pragma('foreign_keys = OFF');
+    db.prepare(
+      `INSERT INTO case_law (document_id, court, case_number, decision_date, summary, keywords)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run(
+      'NJA_2024_s100',
+      'HD',
+      'B 9999-23',
+      '2024-04-15',
+      'Avgörande om regressionsstämning utan motsvarande post i legal_documents.',
+      'regression case_law join'
+    );
+    db.pragma('foreign_keys = ON');
+
+    const response = await searchCaseLaw(db, { query: 'regressionsstämning' });
+    const orphan = response.results.find(r => r.document_id === 'NJA_2024_s100');
+    expect(orphan).toBeDefined();
+    expect(orphan?.court).toBe('HD');
+    expect(orphan?.case_number).toBe('B 9999-23');
+    expect(orphan?.title).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Why

Promotes the case-law search bug fix from dev to main so the GHCR `:latest` image rebuilds and Watchtower can pull the fix to prod.

## What's in here

- **fix(case-law)**: LEFT JOIN so search returns rows not linked to legal_documents (PR #46). The hot fix that resolves prod returning 0 results for every case_law query despite 12,767 rows in the table.
- Any additional dev commits already present on dev.

## Test plan

- [x] All checks green on PR #46.
- [x] Unit tests: 264 passing (one new regression test added).
- [ ] After main merge: confirm `publish.yml` builds new GHCR `:latest`.
- [ ] After Watchtower one-shot: confirm prod `law-swedish` returns ≥ 100 results for `search_case_law("brott")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)