### PR TITLE
test(case-law): regression for build_legal_stance orphan case_law rows

### DIFF
--- a/tests/tools/build-legal-stance.test.ts
+++ b/tests/tools/build-legal-stance.test.ts
@@ -96,6 +96,37 @@ describe('build_legal_stance', () => {
     expect(response.results.total_citations).toBe(0);
   });
 
+  // Regression: parallel coverage to search-case-law.test.ts. The case_law
+  // branch of build-legal-stance previously used the same INNER JOIN against
+  // legal_documents that hid every production case_law row whose document_id
+  // is not in legal_documents. Without this test, a future revert of the
+  // LEFT JOIN in build-legal-stance.ts would slip through CI.
+  it('should aggregate case_law rows whose document_id is not in legal_documents', async () => {
+    db.pragma('foreign_keys = OFF');
+    db.prepare(
+      `INSERT INTO case_law (document_id, court, case_number, decision_date, summary, keywords)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run(
+      'NJA_2024_s200',
+      'HD',
+      'B 8888-23',
+      '2024-04-15',
+      'Avgörande om juristkonsultationsplikt utan motsvarande post i legal_documents.',
+      'juristkonsultationsplikt regression case_law join'
+    );
+    db.pragma('foreign_keys = ON');
+
+    const response = await buildLegalStance(db, {
+      query: 'juristkonsultationsplikt',
+      include_provisions: false,
+      include_preparatory_works: false,
+    });
+    const orphan = response.results.case_law.find(c => c.document_id === 'NJA_2024_s200');
+    expect(orphan).toBeDefined();
+    expect(orphan?.court).toBe('HD');
+    expect(orphan?.title).toBeTruthy();
+  });
+
   it('should apply as_of_date to historical retrieval', async () => {
     const response = await buildLegalStance(db, {
       query: 'Datainspektionen',


### PR DESCRIPTION
## Why

Closes the test-coverage gap flagged after PR #46 merged: the case-law fix in `build-legal-stance.ts:209` (LEFT JOIN + COALESCE on `legal_documents`) had no regression test, even though the parallel fix in `search-case-law.ts` did. Without this, a future revert of the LEFT JOIN in build-legal-stance would slip through CI.

## What

Adds one test in `tests/tools/build-legal-stance.test.ts`. Inserts a `case_law` row with a `document_id` absent from `legal_documents` (matching prod data shape), calls `buildLegalStance` with `include_provisions=false` and `include_preparatory_works=false` to isolate the case_law path, asserts the orphan row is returned with a non-empty title.

## TDD discipline check

- Passes on current code (LEFT JOIN in place).
- Fails when LEFT JOIN is reverted to INNER JOIN (verified locally).

No source changes — test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)