### PR TITLE
feat(tier): drop ParlaMint-SE / agency_guidance capability (ADR-024 pilot prereq P0-3)

### DIFF
--- a/scripts/build-db-paid.ts
+++ b/scripts/build-db-paid.ts
@@ -54,32 +54,6 @@ CREATE TABLE IF NOT EXISTS preparatory_works_full (
 
 CREATE INDEX IF NOT EXISTS idx_prep_works_full_prep
   ON preparatory_works_full(prep_work_id);
-
--- Agency guidance documents (paid tier)
-CREATE TABLE IF NOT EXISTS agency_guidance (
-  id INTEGER PRIMARY KEY,
-  agency TEXT NOT NULL,
-  document_id TEXT NOT NULL UNIQUE,
-  title TEXT NOT NULL,
-  summary TEXT,
-  full_text TEXT,
-  issued_date TEXT,
-  url TEXT,
-  related_statute_id TEXT REFERENCES legal_documents(id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_agency_guidance_agency
-  ON agency_guidance(agency);
-CREATE INDEX IF NOT EXISTS idx_agency_guidance_statute
-  ON agency_guidance(related_statute_id);
-
--- FTS5 for agency guidance search
-CREATE VIRTUAL TABLE IF NOT EXISTS agency_guidance_fts USING fts5(
-  title, summary, full_text,
-  content='agency_guidance',
-  content_rowid='id',
-  tokenize='unicode61'
-);
 `;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -139,7 +113,7 @@ function buildPaidTier(): void {
   console.log(`    Preparatory works: ${prepCount.toLocaleString()}`);
 
   // Check paid tables for data
-  const paidTables = ['case_law_full', 'preparatory_works_full', 'agency_guidance'];
+  const paidTables = ['case_law_full', 'preparatory_works_full'];
   console.log(`\n  Paid-tier tables (stub — no data sources connected yet):`);
   for (const table of paidTables) {
     const row = db.prepare(`SELECT COUNT(*) as c FROM ${table}`).get() as { c: number };
@@ -178,7 +152,6 @@ function buildPaidTier(): void {
   console.log(`\n  NOTE: Paid-tier tables are empty stubs. To populate them:`);
   console.log(`    1. case_law_full -- needs full-text opinion source (future)`);
   console.log(`    2. preparatory_works_full -- needs Riksdagen full-text API (future)`);
-  console.log(`    3. agency_guidance -- needs agency document scrapers (future)`);
 }
 
 buildPaidTier();

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -18,7 +18,6 @@ export type Capability =
   | 'eu_references'
   | 'expanded_case_law'
   | 'full_preparatory_works'
-  | 'agency_guidance'
   | 'version_tracking';
 
 export type Tier = 'free' | 'professional' | 'unknown';
@@ -40,14 +39,12 @@ const CAPABILITY_TABLES: Record<Capability, string> = {
   eu_references: 'eu_references',
   expanded_case_law: 'case_law_full',
   full_preparatory_works: 'preparatory_works_full',
-  agency_guidance: 'agency_guidance',
   version_tracking: 'legal_provision_versions',
 };
 
 const PROFESSIONAL_CAPABILITIES: Capability[] = [
   'expanded_case_law',
   'full_preparatory_works',
-  'agency_guidance',
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -29,7 +29,6 @@ function createPaidTierDb(): InstanceType<typeof Database> {
   db.exec(`
     CREATE TABLE case_law_full (id INTEGER PRIMARY KEY, full_text TEXT);
     CREATE TABLE preparatory_works_full (id INTEGER PRIMARY KEY, full_text TEXT);
-    CREATE TABLE agency_guidance (id INTEGER PRIMARY KEY, guidance TEXT);
   `);
   return db;
 }
@@ -70,12 +69,11 @@ describe('detectCapabilities', () => {
     // Paid capabilities should NOT be present
     expect(caps.has('expanded_case_law')).toBe(false);
     expect(caps.has('full_preparatory_works')).toBe(false);
-    expect(caps.has('agency_guidance')).toBe(false);
 
     expect(caps.size).toBe(3);
   });
 
-  it('should detect all capabilities on paid-tier DB (6 tables)', () => {
+  it('should detect all capabilities on paid-tier DB (5 tables)', () => {
     db = createPaidTierDb();
     const caps = detectCapabilities(db);
 
@@ -84,9 +82,8 @@ describe('detectCapabilities', () => {
     expect(caps.has('eu_references')).toBe(true);
     expect(caps.has('expanded_case_law')).toBe(true);
     expect(caps.has('full_preparatory_works')).toBe(true);
-    expect(caps.has('agency_guidance')).toBe(true);
 
-    expect(caps.size).toBe(6);
+    expect(caps.size).toBe(5);
   });
 
   it('should return empty set for empty database', () => {
@@ -187,7 +184,6 @@ describe('isProfessionalCapability', () => {
   it('should return true for paid capabilities', () => {
     expect(isProfessionalCapability('expanded_case_law')).toBe(true);
     expect(isProfessionalCapability('full_preparatory_works')).toBe(true);
-    expect(isProfessionalCapability('agency_guidance')).toBe(true);
   });
 
   it('should return false for free capabilities', () => {

--- a/tests/tier-gating.test.ts
+++ b/tests/tier-gating.test.ts
@@ -32,7 +32,6 @@ function createProfessionalDb(): InstanceType<typeof Database> {
   db.exec(`
     CREATE TABLE case_law_full (id INTEGER PRIMARY KEY, full_text TEXT);
     CREATE TABLE preparatory_works_full (id INTEGER PRIMARY KEY, full_text TEXT);
-    CREATE TABLE agency_guidance (id INTEGER PRIMARY KEY, guidance TEXT);
   `);
   return db;
 }
@@ -56,7 +55,6 @@ describe('Tier gating', () => {
       const caps = detectCapabilities(db);
       expect(caps.has('expanded_case_law')).toBe(true);
       expect(caps.has('full_preparatory_works')).toBe(true);
-      expect(caps.has('agency_guidance')).toBe(true);
       db.close();
     });
   });


### PR DESCRIPTION
## Summary

ADR-024 Phase 3 Swedish pilot prerequisite **P0-3** from the 2026-04-21 Swedish-law audit ([`docs/audits/2026-04-21/swedish-law.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/audits/2026-04-21/swedish-law.md) in the arch-docs repo).

Drops the ``agency_guidance`` capability + schema from this MCP. The table was being used to serve **84,661 Riksdag parliamentary debate transcripts** (ParlaMint-SE v5.0) under an ``agency_guidance`` label — citing an MP's floor speech as IMY regulatory guidance is a malpractice-grade failure mode for a legal-research MCP. Decision: drop the feature; ParlaMint is political-science data, not legal research.

## Scope turned out to be small

The exploration revealed that ``agency_guidance`` in this codebase is **an empty schema stub** — ``scripts/build-db-paid.ts`` explicitly comments it as "needs agency document scrapers (future)" and no ingest pipeline exists in the repo. The 84,661 live rows on Hetzner's premium DB came from an external/offline pipeline that's not checked in. This PR removes the stub from code; the next premium DB rebuild (separate task) will omit the table physically.

## Diff (39 deletions, 3 insertions; 4 files)

| File | Change |
|---|---|
| ``scripts/build-db-paid.ts`` | Remove CREATE TABLE + 2 indexes + FTS5 virtual table for ``agency_guidance``; drop from ``paidTables`` array; drop from post-build NOTE. |
| ``src/capabilities.ts`` | Remove ``'agency_guidance'`` from ``Capability`` type union, ``CAPABILITY_TABLES``, ``PROFESSIONAL_CAPABILITIES``. |
| ``tests/capabilities.test.ts`` | Remove mock table create + 4 assertions; update "6 tables" → "5 tables" header + size assertion. |
| ``tests/tier-gating.test.ts`` | Remove mock table create + 1 assertion. |

## Verification

- ``tsc --noEmit``: clean
- ``npx vitest run tests/capabilities.test.ts tests/tier-gating.test.ts``: **27/27 pass**
- Full suite (``npx vitest run``): 265/282 pass. **The 17 failing tests are pre-existing on ``dev``** — confirmed by stashing my changes and running the same suite on unmodified dev HEAD: identical 17 failures in ``__tests__/contract/golden.test.ts``. These tests need a populated DB fixture not present in this environment. Not caused by this PR.

No tool ever registered ``search_agency_guidance``; no docs advertise it; ``sources.yml`` has no ParlaMint entry; no ingestion script references it. Removing it touches no user-facing runtime surface.

## Follow-ups (not in this PR)

1. After this PR lands on ``main``, the manifest in arch-docs (``backstage/catalog/fleet-manifests/swedish-law.json``) needs corresponding cleanup: remove ``premium.categories.agency_guidance`` stanza + ``premium_stats.parliamentary_speeches*`` + ParlaMint line from ``premium_sources``. Separate PR (tracked).
2. Rebuild Swedish premium DB on dev; verify ``scripts/audit-premium-db.sh`` 6-gate passes; confirm the 84,661 parliamentary-speech rows are gone from the new image.
3. P1-2 provision-title fix (audit item P1-2) — scope TBD; different root cause than P0-3.
4. Phase 3 unified-image rollout (after all Phase 3 pilot prerequisites land).

## Related

- ADR-024 acceptance: [PR #165 in Ansvar-Architecture-Documentation](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/pull/165)
- Phase 0a text consequences: [PR #166](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/pull/166)
- P1-4 manifest fix: [PR #167](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/pull/167)

🤖 Generated with [Claude Code](https://claude.com/claude-code)