### PR TITLE
feat(tools): display_ref field on get_provision + search_legislation (ADR-024 P1-2)

### DIFF
--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -6,6 +6,7 @@ import type { Database } from '@ansvar/mcp-sqlite';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 import { buildProvisionCitation } from '../utils/citation.js';
+import { buildDisplayRef } from '../utils/provision-display.js';
 
 export interface GetProvisionInput {
   document_id: string;
@@ -23,6 +24,13 @@ export interface ProvisionResult {
   chapter: string | null;
   section: string;
   title: string | null;
+  /**
+   * Swedish-convention display label computed from chapter + section —
+   * e.g. "1 kap. 1 §" or "4 §". Populated for every row so callers have
+   * a navigation label regardless of whether the source data carries a
+   * per-section rubrik. `title` stays null when no source rubrik exists.
+   */
+  display_ref: string;
   content: string;
   metadata: Record<string, unknown> | null;
   cross_references: CrossRefResult[];
@@ -150,6 +158,7 @@ export async function getProvision(
   return {
     results: {
       ...row,
+      display_ref: buildDisplayRef(row.chapter, row.section),
       metadata: row.metadata ? JSON.parse(row.metadata) : null,
       cross_references: crossRefs,
     },
@@ -237,6 +246,7 @@ function getAllProvisions(db: Database, documentId: string, asOfDate?: string, l
 
   return rows.map(row => ({
     ...row,
+    display_ref: buildDisplayRef(row.chapter, row.section),
     metadata: row.metadata ? JSON.parse(row.metadata) : null,
     cross_references: [],
   }));

--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -7,6 +7,7 @@ import { buildFtsQueryVariants } from '../utils/fts-query.js';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
 import { resolveDocumentId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
+import { buildDisplayRef } from '../utils/provision-display.js';
 
 export interface SearchLegislationInput {
   query: string;
@@ -23,6 +24,13 @@ export interface SearchLegislationResult {
   chapter: string | null;
   section: string;
   title: string | null;
+  /**
+   * Swedish-convention display label computed from chapter + section
+   * (e.g. "1 kap. 1 §" or "4 §"). Populated even when `title` is null so
+   * callers have a navigation label; source rubrik coverage is ~6% of
+   * the corpus by design.
+   */
+  display_ref: string;
   snippet: string;
   relevance: number;
   valid_from?: string | null;
@@ -160,7 +168,8 @@ export async function searchLegislation(
 
   const runQuery = (ftsQuery: string): SearchLegislationResult[] => {
     const bound = [ftsQuery, ...params];
-    return db.prepare(sql).all(...bound) as SearchLegislationResult[];
+    const rows = db.prepare(sql).all(...bound) as Omit<SearchLegislationResult, 'display_ref'>[];
+    return rows.map(r => ({ ...r, display_ref: buildDisplayRef(r.chapter, r.section) }));
   };
 
   const primaryResults = runQuery(queryVariants.primary);

--- a/src/utils/provision-display.ts
+++ b/src/utils/provision-display.ts
@@ -1,0 +1,21 @@
+/**
+ * Format a Swedish provision reference as a display label.
+ *
+ * Swedish statute convention: "N kap. M §" when a chapter is present,
+ * "M §" when the statute is not chapter-divided. Used as a caller-safe
+ * fallback when legal_provisions.title is null — which, empirically, is
+ * ~94% of the corpus (seed scan 2026-04-22: 3,691 of 59,888 provisions
+ * carry a source-provided rubrik). Returning a computed ref as "title"
+ * would be inventing data; surfacing display_ref as a separate field
+ * keeps `title` honest.
+ *
+ * The helper trims whitespace and collapses empty strings to null so
+ * trailing "kap. §" artefacts can't slip through when the DB stores
+ * "" instead of NULL.
+ */
+export function buildDisplayRef(chapter: string | null | undefined, section: string): string {
+  const sec = (section ?? '').trim();
+  const chap = (chapter ?? '').trim();
+  if (chap && sec) return `${chap} kap. ${sec} §`;
+  return `${sec} §`;
+}

--- a/tests/utils/provision-display.test.ts
+++ b/tests/utils/provision-display.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { buildDisplayRef } from '../../src/utils/provision-display.js';
+
+describe('buildDisplayRef', () => {
+  it('formats chapter + section in Swedish convention', () => {
+    expect(buildDisplayRef('1', '1')).toBe('1 kap. 1 §');
+    expect(buildDisplayRef('3', '12')).toBe('3 kap. 12 §');
+  });
+
+  it('omits chapter when absent', () => {
+    expect(buildDisplayRef(null, '4')).toBe('4 §');
+    expect(buildDisplayRef(undefined, '7')).toBe('7 §');
+  });
+
+  it('omits chapter when empty string (DB "" vs NULL drift)', () => {
+    expect(buildDisplayRef('', '2')).toBe('2 §');
+    expect(buildDisplayRef('   ', '5')).toBe('5 §');
+  });
+
+  it('handles whitespace in section', () => {
+    expect(buildDisplayRef('1', ' 2 ')).toBe('1 kap. 2 §');
+  });
+
+  it('never returns a value containing "undefined" or "null" strings', () => {
+    expect(buildDisplayRef(null, '1')).not.toContain('null');
+    expect(buildDisplayRef(undefined, '1')).not.toContain('undefined');
+  });
+});


### PR DESCRIPTION
## Summary

ADR-024 Phase 3 Swedish pilot prerequisite **P1-2** from the 2026-04-21 Swedish-law audit. Corrected fix direction — adds a ``display_ref`` computed field instead of trying to populate ``title`` with synthetic data.

## Why the original audit diagnosis was wrong

The audit reported **"``title: null`` across every result"** on ``get_provision`` and ``search_legislation`` and proposed populating the title via an ingestion fix.

On investigation, that diagnosis is wrong. A **seed-data scan across 2,159 Swedish statute documents / 59,888 provisions** (run 2026-04-22 against ``data/seed/*.json``):

| Metric | Value |
|---|---|
| Total provisions | 59,888 |
| Provisions with a source-provided rubrik | **3,691 (6.2%)** |
| Documents with at least one titled provision | 1,208 (56%) |
| Documents with zero titled provisions | 951 (44%) |

Swedish statute convention: **most sections are unnamed**. Populating ``title`` by synthesising one would invent data — fatal for a legal-research MCP. A lawyer needs to know whether a rubrik is real or synthetic.

## Fix: additive ``display_ref`` field

Compute a caller-safe navigation label from ``chapter`` + ``section`` using Swedish convention:

- Chapter present → ``"N kap. M §"`` (e.g. ``"1 kap. 1 §"``)
- No chapter → ``"M §"`` (e.g. ``"4 §"``)

``title`` stays null when source has no rubrik (honest semantics). Every row carries ``display_ref`` so UIs have a consistent navigation label.

## Diff

| File | Change |
|---|---|
| ``src/utils/provision-display.ts`` (new) | ``buildDisplayRef`` helper with whitespace / null / empty-string guards (handles `""` vs NULL DB drift). |
| ``src/tools/get-provision.ts`` | Added ``display_ref`` to ``ProvisionResult``; populated in single-result path + ``getAllProvisions`` map. |
| ``src/tools/search-legislation.ts`` | Added ``display_ref`` to ``SearchLegislationResult``; ``runQuery`` maps rows through the helper pre-dedup. |
| ``tests/utils/provision-display.test.ts`` (new) | 5 tests: chapter+section, chapter absent, empty-string chapter, whitespace, no ``"null"``/``"undefined"`` string leakage. |

69 insertions, 1 deletion.

## Verification

- ``tsc --noEmit``: clean
- ``vitest tests/utils/provision-display.test.ts``: 5/5 pass
- Full suite: **270/287 pass**. The 17 failing tests are pre-existing on ``dev`` (``__tests__/contract/golden.test.ts`` requires a populated DB fixture not present in this environment); confirmed unchanged from dev HEAD.

## Non-goals

- **No DB rebuild.** Read-time only. ``title`` column semantics unchanged.
- **No schema change.**
- **No ingestion change.** If someone later wants to extract more rubriker from source HTML/XML, that's a separate effort — and would still want ``display_ref`` as the fallback.
- **Backwards compatible.** Callers that ignore ``display_ref`` see their existing response shape.

## Related

- ADR-024 acceptance: [PR #165](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/pull/165) (text needs a fixup to match the corrected P1-2 framing — separate fixup commit)
- Other Swedish pilot prerequisites:
  - P0-3 drop ParlaMint: [PR #56](https://github.com/Ansvar-Systems/Swedish-law-mcp/pull/56) — separate, independent
  - P1-4 manifest ``public_endpoint``: [arch-docs PR #167](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/pull/167)

🤖 Generated with [Claude Code](https://claude.com/claude-code)