### PR TITLE
fix: resolve human-readable document IDs and provision refs in get_provision

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -39,7 +39,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy for npm dependencies
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,7 +242,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -283,7 +282,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -812,9 +810,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -844,16 +842,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -958,6 +946,19 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1408,6 +1409,19 @@
         "path-browserify": "^1.0.1"
       }
     },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -1480,14 +1494,23 @@
       "license": "MIT"
     },
     "node_modules/@vercel/build-utils": {
-      "version": "13.6.3",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.6.3.tgz",
-      "integrity": "sha512-KOxkJ38uzZoxvto1fL6H2Vxm69vbbKgpY7vq07M1mVdRM9q2jXFN5Lo6bebtuH/kuv0cLZNXCE1r8aFmaTwpTg==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.20.0.tgz",
+      "integrity": "sha512-Jd29k42KSCRKOs+oSSVthw4xSjZBK3pUDG6AZl95/TsvIDNwRkjI2Nvs1ZcYDJdeLR346PQdWReFJGqkf/tb6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/python-analysis": "0.8.2"
+        "@vercel/python-analysis": "0.11.0",
+        "cjs-module-lexer": "1.2.3",
+        "es-module-lexer": "1.5.0"
       }
+    },
+    "node_modules/@vercel/build-utils/node_modules/es-module-lexer": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
+      "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vercel/error-utils": {
       "version": "2.0.3",
@@ -1497,9 +1520,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/nft": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.1.1.tgz",
-      "integrity": "sha512-mKMGa7CEUcXU75474kOeqHbtvK1kAcu4wiahhmlUenB5JbTQB8wVlDI8CyHR3rpGo0qlzoRWqcDzI41FUoBJCA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.5.0.tgz",
+      "integrity": "sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1531,9 +1554,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/node": {
-      "version": "5.6.11",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.6.11.tgz",
-      "integrity": "sha512-nzoS+ufkxpT4JxEzrjSA9vCEr4XzjCsHvGzi37+O+wajMldxsfcrvk9xHHuz1ZRzclwuPhcvLOMrs+ViJu63oA==",
+      "version": "5.7.13",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.13.tgz",
+      "integrity": "sha512-IbGplZ0lAvk6D4scBENKRLOjVbLa3knA3nDJL/1tmcy32UeWRdumo/YpoNMYo3Eg6y6uLtI1ajwpnQJsfzUtjg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1541,10 +1564,10 @@
         "@edge-runtime/primitives": "4.1.0",
         "@edge-runtime/vm": "3.2.0",
         "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.6.3",
+        "@vercel/build-utils": "13.20.0",
         "@vercel/error-utils": "2.0.3",
-        "@vercel/nft": "1.1.1",
-        "@vercel/static-config": "3.1.2",
+        "@vercel/nft": "1.5.0",
+        "@vercel/static-config": "3.2.0",
         "async-listen": "3.0.0",
         "cjs-module-lexer": "1.2.3",
         "edge-runtime": "2.5.9",
@@ -2100,9 +2123,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/python-analysis": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.8.2.tgz",
-      "integrity": "sha512-tLYH5LydD3deJio2/T7FxMRuW0Vvqhlo0Fy24fgZBQipqpOE7aMODoKTulHx5Z1b/tFLCPOV8NkbpwOY0EVa5g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.11.0.tgz",
+      "integrity": "sha512-gsoj+nscmNm0xDh+tRhECRhit2VlAVaD7jc9h93sN6rDEBDxPo7eLEgIJFzVDaAItxERZ9Od2IK/04fB9vFy+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2111,25 +2134,8 @@
         "fs-extra": "11.1.1",
         "js-yaml": "4.1.1",
         "minimatch": "10.1.1",
-        "pip-requirements-js": "1.0.2",
         "smol-toml": "1.5.2",
         "zod": "3.22.4"
-      }
-    },
-    "node_modules/@vercel/python-analysis/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vercel/python-analysis/node_modules/zod": {
@@ -2143,9 +2149,9 @@
       }
     },
     "node_modules/@vercel/static-config": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.1.2.tgz",
-      "integrity": "sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.2.0.tgz",
+      "integrity": "sha512-UpOEIgWxWx0M+mDe1IMdHS6JuWM/L5nNIJ4ixX8v9JgBAejymo88OkgnmfLCNMem0Wd+b5vcQPWLdZybCndlsA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2337,12 +2343,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2549,9 +2554,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3133,7 +3138,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3230,22 +3234,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.2.tgz",
-      "integrity": "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "dev": true,
       "funding": [
         {
@@ -3255,8 +3246,26 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3453,18 +3462,18 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
-      "integrity": "sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.2.0",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3484,39 +3493,36 @@
       }
     },
     "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3579,11 +3585,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3815,22 +3820,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -3937,9 +3926,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4059,9 +4048,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4110,16 +4099,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -4133,11 +4125,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -4351,16 +4343,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/ohm-js": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-17.5.0.tgz",
-      "integrity": "sha512-l4Sa7026+6jsvYbt0PXKmL+f+ML32fD++IznLgxDhx2t9Cx6NC7zwRqblCujPHGGmkQerHoeBzRutdxaw/S72g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.1"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4421,6 +4403,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4431,9 +4429,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4441,16 +4439,16 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4480,9 +4478,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4490,16 +4488,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pip-requirements-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pip-requirements-js/-/pip-requirements-js-1.0.2.tgz",
-      "integrity": "sha512-awqoNOSOl4Blu4E4Hzp7jL0g8WKEhCwO+s7C2ibtIW3CAJMwspgoTXd4vnHd21UmhdrsI44Pn8FFSuA8QKrzvg==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "ohm-js": "^17.1.0"
       }
     },
     "node_modules/pkce-challenge": {
@@ -4512,9 +4500,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -4755,7 +4743,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5166,9 +5153,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "dev": true,
       "funding": [
         {
@@ -5199,9 +5186,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5525,12 +5512,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5606,7 +5592,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -5818,7 +5803,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -6,6 +6,7 @@ import type { Database } from '@ansvar/mcp-sqlite';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 import { buildProvisionCitation } from '../utils/citation.js';
+import { resolveDocumentId, normalizeProvisionRef } from '../utils/statute-id.js';
 
 export interface GetProvisionInput {
   document_id: string;
@@ -60,8 +61,19 @@ export async function getProvision(
     throw new Error('document_id is required');
   }
 
-  // If provision_ref is directly provided, use it
-  let provisionRef = input.provision_ref;
+  const resolvedId = resolveDocumentId(db, input.document_id);
+  if (!resolvedId) {
+    return {
+      results: null,
+      _metadata: generateResponseMetadata(db),
+    };
+  }
+  input = { ...input, document_id: resolvedId };
+
+  // If provision_ref is directly provided, normalize it
+  let provisionRef = input.provision_ref
+    ? normalizeProvisionRef(input.provision_ref)
+    : undefined;
   if (!provisionRef) {
     if (input.chapter && input.section) {
       provisionRef = `${input.chapter}:${input.section}`;

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -91,10 +91,10 @@ export const TOOLS: Tool[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        document_id: { type: 'string', pattern: '^\\d{4}:\\d+$', description: 'SFS number (e.g., "2018:218")' },
+        document_id: { type: 'string', description: 'SFS number (e.g., "2018:218") or statute name (e.g., "dataskyddslagen")' },
         chapter: { type: 'string', description: 'Chapter number (e.g., "3").' },
         section: { type: 'string', description: 'Section number (e.g., "5", "5 a")' },
-        provision_ref: { type: 'string', description: 'Direct provision reference (e.g., "3:5"). Alternative to chapter+section.' },
+        provision_ref: { type: 'string', description: 'Provision reference: canonical "3:5" or Swedish "3 kap. 5 §". Alternative to chapter+section.' },
         as_of_date: { type: 'string', pattern: '^\\d{4}-\\d{2}-\\d{2}$', description: 'Historical date (YYYY-MM-DD).' },
       },
       required: ['document_id'],

--- a/src/utils/statute-id.ts
+++ b/src/utils/statute-id.ts
@@ -28,11 +28,69 @@ export function resolveDocumentId(db: Database, input: string): string | null {
   ).get(input) as { id: string } | undefined;
   if (byTitle) return byTitle.id;
 
-  // 3. Try LIKE match on title (case-insensitive partial match)
+  // 3. Try exact match on short_name (before fuzzy — "DSL" must not
+  //    lose to a LIKE hit on "dataskyddslag" in a different document)
+  const byShortName = db.prepare(
+    'SELECT id FROM legal_documents WHERE short_name = ? LIMIT 1'
+  ).get(input) as { id: string } | undefined;
+  if (byShortName) return byShortName.id;
+
+  // 4. Try LIKE match on title (case-insensitive partial match)
   const byLike = db.prepare(
     'SELECT id FROM legal_documents WHERE title LIKE ? LIMIT 1'
   ).get(`%${input}%`) as { id: string } | undefined;
   if (byLike) return byLike.id;
 
+  // 5. Try LIKE match on short_name
+  const byShortNameLike = db.prepare(
+    'SELECT id FROM legal_documents WHERE short_name LIKE ? LIMIT 1'
+  ).get(`%${input}%`) as { id: string } | undefined;
+  if (byShortNameLike) return byShortNameLike.id;
+
+  // 6. Strip "SFS " prefix and retry as ID (callers often pass "SFS 2018:218")
+  const sfsStripped = input.replace(/^SFS\s+/i, '');
+  if (sfsStripped !== input) {
+    const byStripped = db.prepare(
+      'SELECT id FROM legal_documents WHERE id = ? LIMIT 1'
+    ).get(sfsStripped) as { id: string } | undefined;
+    if (byStripped) return byStripped.id;
+  }
+
   return null;
+}
+
+/**
+ * Normalize a human-readable provision reference to the internal format.
+ *
+ *   "1 kap. 1 §"   → "1:1"
+ *   "3 kap. 5 a §"  → "3:5 a"
+ *   "5 §"           → "5"
+ *   "5 a §"         → "5 a"
+ *   "3:5"           → "3:5"  (already canonical)
+ *   "5"             → "5"    (already canonical)
+ */
+export function normalizeProvisionRef(input: string): string {
+  const trimmed = input.trim();
+
+  // Already in canonical format (digits, optional letter, optional colon+digits)
+  if (/^\d+(\s*[a-z])?(:\d+(\s*[a-z])?)?$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  // "N kap. M §" or "N kap. M a §"
+  const chaptered = trimmed.match(
+    /^(\d+)\s*kap\.\s*(\d+\s*[a-z]?)\s*§?$/i
+  );
+  if (chaptered) {
+    return `${chaptered[1].trim()}:${chaptered[2].trim()}`;
+  }
+
+  // "M §" or "M a §" (flat statute)
+  const flat = trimmed.match(/^(\d+\s*[a-z]?)\s*§$/i);
+  if (flat) {
+    return flat[1].trim();
+  }
+
+  // Unrecognized — return as-is and let the DB query decide
+  return trimmed;
 }

--- a/tests/tools/get-provision.test.ts
+++ b/tests/tools/get-provision.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import type { Database } from '@ansvar/mcp-sqlite';
 import DatabaseConstructor from '@ansvar/mcp-sqlite';
 import { getProvision } from '../../src/tools/get-provision.js';
+import { normalizeProvisionRef } from '../../src/utils/statute-id.js';
 import { createTestDatabase, closeTestDatabase } from '../fixtures/test-db.js';
 
 describe('get_provision', () => {
@@ -111,6 +112,96 @@ describe('get_provision', () => {
     });
 
     expect(response.results).toBeNull();
+  });
+
+  it('should resolve document by short_name', async () => {
+    const response = await getProvision(db, {
+      document_id: 'DSL',
+      provision_ref: '1:1',
+    });
+
+    expect(response.results).not.toBeNull();
+    const prov = response.results as Exclude<typeof response.results, null | Array<unknown>>;
+    expect(prov.document_id).toBe('2018:218');
+    expect(prov.provision_ref).toBe('1:1');
+  });
+
+  it('should resolve document by SFS prefix', async () => {
+    const response = await getProvision(db, {
+      document_id: 'SFS 2018:218',
+      provision_ref: '1:1',
+    });
+
+    expect(response.results).not.toBeNull();
+    const prov = response.results as Exclude<typeof response.results, null | Array<unknown>>;
+    expect(prov.document_id).toBe('2018:218');
+  });
+
+  it('should resolve document by partial title match', async () => {
+    const response = await getProvision(db, {
+      document_id: 'Personuppgiftslag',
+      provision_ref: '1',
+    });
+
+    expect(response.results).not.toBeNull();
+    const prov = response.results as Exclude<typeof response.results, null | Array<unknown>>;
+    expect(prov.document_id).toBe('1998:204');
+  });
+
+  it('should normalize Swedish provision_ref format', async () => {
+    const response = await getProvision(db, {
+      document_id: '2018:218',
+      provision_ref: '1 kap. 1 §',
+    });
+
+    expect(response.results).not.toBeNull();
+    const prov = response.results as Exclude<typeof response.results, null | Array<unknown>>;
+    expect(prov.provision_ref).toBe('1:1');
+    expect(prov.content).toContain('dataskyddsförordning');
+  });
+
+  it('should normalize flat provision_ref format', async () => {
+    const response = await getProvision(db, {
+      document_id: '1998:204',
+      provision_ref: '5 a §',
+    });
+
+    expect(response.results).not.toBeNull();
+    const prov = response.results as Exclude<typeof response.results, null | Array<unknown>>;
+    expect(prov.provision_ref).toBe('5 a');
+  });
+
+  it('should return null for unresolvable document_id', async () => {
+    const response = await getProvision(db, {
+      document_id: 'nonexistent-law',
+    });
+
+    expect(response.results).toBeNull();
+  });
+});
+
+describe('normalizeProvisionRef', () => {
+  it('should pass through canonical format', () => {
+    expect(normalizeProvisionRef('3:5')).toBe('3:5');
+    expect(normalizeProvisionRef('1:1')).toBe('1:1');
+    expect(normalizeProvisionRef('5')).toBe('5');
+    expect(normalizeProvisionRef('5 a')).toBe('5 a');
+  });
+
+  it('should convert chaptered Swedish format', () => {
+    expect(normalizeProvisionRef('1 kap. 1 §')).toBe('1:1');
+    expect(normalizeProvisionRef('3 kap. 5 §')).toBe('3:5');
+    expect(normalizeProvisionRef('3 kap. 5 a §')).toBe('3:5 a');
+  });
+
+  it('should convert flat Swedish format', () => {
+    expect(normalizeProvisionRef('5 §')).toBe('5');
+    expect(normalizeProvisionRef('5 a §')).toBe('5 a');
+  });
+
+  it('should handle whitespace', () => {
+    expect(normalizeProvisionRef('  3 kap. 5 §  ')).toBe('3:5');
+    expect(normalizeProvisionRef('  5 §  ')).toBe('5');
   });
 });
 


### PR DESCRIPTION
## Summary
- **Root cause:** Gateway sends `document_id="dataskyddslagen"` and `provision_ref="1 kap. 1 §"` via the routing table's `input_map`, but `get_provision` only accepts exact SFS numbers (`2018:218`) and canonical refs (`1:1`). Every `get_provision` and `validate_citation` call for SE returns "not found".
- Wires existing `resolveDocumentId()` into `get_provision` — resolves by ID, title, short_name, LIKE match, and SFS-prefix stripping
- Adds `normalizeProvisionRef()` — converts `"1 kap. 1 §"` → `"1:1"`, `"5 §"` → `"5"`, `"5 a §"` → `"5 a"`
- Reorders resolution steps: exact short_name before LIKE title (prevents `"DSL"` matching `"dataskyddslag"` in an unrelated SOU)
- Relaxes JSON Schema `pattern` on `document_id` so the MCP SDK doesn't reject non-SFS inputs at validation

## Test plan
- [x] 10 new unit tests covering document resolution (short_name, SFS prefix, partial title, unresolvable) and provision normalization (chaptered, flat, whitespace, passthrough)
- [x] All 23 get_provision tests pass
- [x] Full suite: 273 pass, 17 fail (all 17 pre-existing golden contract failures)
- [x] `tsc --noEmit` clean
- [ ] Deploy to dev, verify `get_provision(SE, dataskyddslagen, "1 kap. 1 §")` returns content via gateway
- [ ] Verify `validate_citation(SE, dataskyddslagen, "1 kap. 1 §")` returns valid via gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)