### PR TITLE
Gateway interaction standard: _meta rename + colloquial aliases

### DIFF
--- a/src/tools/build-legal-stance.ts
+++ b/src/tools/build-legal-stance.ts
@@ -93,7 +93,7 @@ export async function buildLegalStance(
   if (!input.query || input.query.trim().length === 0) {
     return {
       results: { query: '', provisions: [], case_law: [], preparatory_works: [], total_citations: 0 },
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
@@ -115,7 +115,7 @@ export async function buildLegalStance(
     if (!resolved) {
       return {
         results: { query: input.query, provisions: [], case_law: [], preparatory_works: [], total_citations: 0 },
-        _metadata: {
+        _meta: {
           ...generateResponseMetadata(db),
           note: `No document found matching "${input.document_id}"`,
         },
@@ -280,7 +280,7 @@ export async function buildLegalStance(
       total_citations: provisions.length + caseLaw.length + prepWorks.length,
       as_of_date: asOfDate,
     },
-    _metadata: {
+    _meta: {
       ...generateResponseMetadata(db),
       ...(usedFallback ? { query_strategy: 'broadened' } : {}),
     },

--- a/src/tools/check-currency.ts
+++ b/src/tools/check-currency.ts
@@ -65,7 +65,7 @@ export async function checkCurrency(
   if (!doc) {
     return {
       results: null,
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
@@ -156,6 +156,6 @@ export async function checkCurrency(
       warnings,
       case_law_stats: caseLawStats,
     },
-    _metadata: generateResponseMetadata(db)
+    _meta: generateResponseMetadata(db)
   };
 }

--- a/src/tools/format-citation.ts
+++ b/src/tools/format-citation.ts
@@ -26,7 +26,7 @@ export async function formatCitationTool(
   if (!input.citation || input.citation.trim().length === 0) {
     return {
       results: { input: '', formatted: '', type: 'unknown', valid: false, error: 'Empty citation' },
-      _metadata: generateResponseMetadata()
+      _meta: generateResponseMetadata()
     };
   }
 
@@ -41,7 +41,7 @@ export async function formatCitationTool(
         valid: false,
         error: parsed.error,
       },
-      _metadata: generateResponseMetadata()
+      _meta: generateResponseMetadata()
     };
   }
 
@@ -54,6 +54,6 @@ export async function formatCitationTool(
       type: parsed.type,
       valid: true,
     },
-    _metadata: generateResponseMetadata()
+    _meta: generateResponseMetadata()
   };
 }

--- a/src/tools/get-eu-basis.ts
+++ b/src/tools/get-eu-basis.ts
@@ -169,6 +169,6 @@ export async function getEUBasis(
 
   return {
     results: result,
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/tools/get-preparatory-works.ts
+++ b/src/tools/get-preparatory-works.ts
@@ -49,6 +49,6 @@ export async function getPreparatoryWorks(
 
   return {
     results,
-    _metadata: generateResponseMetadata(db)
+    _meta: generateResponseMetadata(db)
   };
 }

--- a/src/tools/get-provision-eu-basis.ts
+++ b/src/tools/get-provision-eu-basis.ts
@@ -243,6 +243,6 @@ export async function getProvisionEUBasis(
 
   return {
     results: result,
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -65,7 +65,7 @@ export async function getProvision(
   if (!resolvedId) {
     return {
       results: null,
-      _metadata: generateResponseMetadata(db),
+      _meta: generateResponseMetadata(db),
     };
   }
   input = { ...input, document_id: resolvedId };
@@ -92,7 +92,7 @@ export async function getProvision(
     return {
       results: truncated ? all.slice(0, MAX_ALL_PROVISIONS) : all,
       ...(truncated && { _truncated: true, _hint: `Only first ${MAX_ALL_PROVISIONS} provisions returned. Use chapter+section to retrieve specific provisions.` }),
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
@@ -149,7 +149,7 @@ export async function getProvision(
   if (!row) {
     return {
       results: null,
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
@@ -165,7 +165,7 @@ export async function getProvision(
       metadata: row.metadata ? JSON.parse(row.metadata) : null,
       cross_references: crossRefs,
     },
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
     _citation: buildProvisionCitation(
       row.document_id,
       row.document_title,

--- a/src/tools/get-swedish-implementations.ts
+++ b/src/tools/get-swedish-implementations.ts
@@ -172,6 +172,6 @@ export async function getSwedishImplementations(
 
   return {
     results: result,
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/tools/search-case-law.ts
+++ b/src/tools/search-case-law.ts
@@ -23,7 +23,7 @@ export interface CaseLawResult {
   summary_snippet: string;
   keywords: string | null;
   relevance: number;
-  _metadata: {
+  _meta: {
     source: string;
     attribution: string;
   };
@@ -39,7 +39,7 @@ export async function searchCaseLaw(
   if (!input.query || input.query.trim().length === 0) {
     return {
       results: [],
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
@@ -88,12 +88,12 @@ export async function searchCaseLaw(
 
   const runQuery = (ftsQuery: string): CaseLawResult[] => {
     const bound = [ftsQuery, ...params];
-    const results = db.prepare(sql).all(...bound) as Omit<CaseLawResult, '_metadata'>[];
+    const results = db.prepare(sql).all(...bound) as Omit<CaseLawResult, '_meta'>[];
 
     // Add attribution metadata to each result
     return results.map(result => ({
       ...result,
-      _metadata: {
+      _meta: {
         source: 'lagen.nu',
         attribution: 'Data from lagen.nu, licensed CC-BY Domstolsverket',
       },
@@ -107,6 +107,6 @@ export async function searchCaseLaw(
 
   return {
     results,
-    _metadata: generateResponseMetadata(db)
+    _meta: generateResponseMetadata(db)
   };
 }

--- a/src/tools/search-eu-implementations.ts
+++ b/src/tools/search-eu-implementations.ts
@@ -165,6 +165,6 @@ export async function searchEUImplementations(
       total_results: results.length,
       query_info: input,
     },
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -39,7 +39,7 @@ export async function searchLegislation(
   if (!input.query || input.query.trim().length === 0) {
     return {
       results: [],
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
@@ -57,7 +57,7 @@ export async function searchLegislation(
     if (!resolved) {
       return {
         results: [],
-        _metadata: {
+        _meta: {
           ...generateResponseMetadata(db),
           note: `No document found matching "${input.document_id}"`,
         },
@@ -167,7 +167,7 @@ export async function searchLegislation(
   if (primaryResults.length > 0) {
     return {
       results: deduplicateResults(primaryResults, limit),
-      _metadata: generateResponseMetadata(db),
+      _meta: generateResponseMetadata(db),
     };
   }
 
@@ -176,7 +176,7 @@ export async function searchLegislation(
     if (fallbackResults.length > 0) {
       return {
         results: deduplicateResults(fallbackResults, limit),
-        _metadata: {
+        _meta: {
           ...generateResponseMetadata(db),
           query_strategy: 'broadened',
         },
@@ -186,7 +186,7 @@ export async function searchLegislation(
 
   return {
     results: [],
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }
 

--- a/src/tools/validate-citation.ts
+++ b/src/tools/validate-citation.ts
@@ -40,7 +40,7 @@ export async function validateCitationTool(
         provision_exists: false,
         warnings: ['Empty citation'],
       },
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
@@ -58,6 +58,6 @@ export async function validateCitationTool(
       status: result.status,
       warnings: result.warnings,
     },
-    _metadata: generateResponseMetadata(db)
+    _meta: generateResponseMetadata(db)
   };
 }

--- a/src/tools/validate-eu-compliance.ts
+++ b/src/tools/validate-eu-compliance.ts
@@ -213,6 +213,6 @@ export async function validateEUCompliance(
 
   return {
     results: result,
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -180,7 +180,7 @@ export interface ToolResponse<T> {
   results: T;
 
   /** Professional-use metadata and warnings */
-  _metadata: ResponseMetadata;
+  _meta: ResponseMetadata;
 
   /** Citation metadata for deterministic citation pipeline (optional) */
   _citation?: import('./citation.js').CitationMetadata;

--- a/src/utils/statute-id.ts
+++ b/src/utils/statute-id.ts
@@ -8,6 +8,29 @@
 
 import type { Database } from '@ansvar/mcp-sqlite';
 
+const COLLOQUIAL_NAMES: Record<string, string> = {
+  'dataskyddslagen': '2018:218',
+  'gdpr-lagen': '2018:218',
+  'personuppgiftslagen': '1998:204',
+  'brottsbalken': '1962:700',
+  'miljöbalken': '1998:808',
+  'skollagen': '2010:800',
+  'regeringsformen': '1974:152',
+  'tryckfrihetsförordningen': '1949:105',
+  'yttrandefrihetsgrundlagen': '1991:1469',
+  'successionsordningen': '1810:0926',
+  'riksdagsordningen': '2014:801',
+  'arbetsmiljölagen': '1977:1160',
+  'diskrimineringslagen': '2008:567',
+  'förvaltningslagen': '2017:900',
+  'kommunallagen': '2017:725',
+  'offentlighets- och sekretesslagen': '2009:400',
+  'plan- och bygglagen': '2010:900',
+  'socialtjänstlagen': '2001:453',
+  'utlänningslagen': '2005:716',
+  'aktiebolagslagen': '2005:551',
+};
+
 /**
  * Resolve a document_id that may be:
  *  1. An exact internal ID (e.g. "1998:808") — returned as-is if it exists
@@ -27,6 +50,16 @@ export function resolveDocumentId(db: Database, input: string): string | null {
     'SELECT id FROM legal_documents WHERE title = ? LIMIT 1'
   ).get(input) as { id: string } | undefined;
   if (byTitle) return byTitle.id;
+
+  // 2.5. Try colloquial name lookup (before fuzzy — "dataskyddslagen" has
+  //      no substring match in the formal title)
+  const colloquial = COLLOQUIAL_NAMES[input.toLowerCase()];
+  if (colloquial) {
+    const byColloquial = db.prepare(
+      'SELECT id FROM legal_documents WHERE id = ? LIMIT 1'
+    ).get(colloquial) as { id: string } | undefined;
+    if (byColloquial) return byColloquial.id;
+  }
 
   // 3. Try exact match on short_name (before fuzzy — "DSL" must not
   //    lose to a LIKE hit on "dataskyddslag" in a different document)

--- a/tests/tier-gating.test.ts
+++ b/tests/tier-gating.test.ts
@@ -114,7 +114,7 @@ describe('Tier gating', () => {
         search_case_law: { capability: 'expanded_case_law', feature: 'Full case law archive' },
       };
 
-      let result: unknown = { results: [], _metadata: {} };
+      let result: unknown = { results: [], _meta: {} };
       const tierInfo = TIER_SENSITIVE_TOOLS['search_case_law'];
 
       if (tierInfo && !capabilities.has(tierInfo.capability)) {
@@ -136,7 +136,7 @@ describe('Tier gating', () => {
         search_case_law: { capability: 'expanded_case_law', feature: 'Full case law archive' },
       };
 
-      const result: Record<string, unknown> = { results: [], _metadata: {} };
+      const result: Record<string, unknown> = { results: [], _meta: {} };
       const tierInfo = TIER_SENSITIVE_TOOLS['search_case_law'];
 
       if (tierInfo && !capabilities.has(tierInfo.capability)) {

--- a/tests/tools/eu-cross-reference.test.ts
+++ b/tests/tools/eu-cross-reference.test.ts
@@ -404,10 +404,10 @@ describe('EU Cross-Reference Tools', () => {
     it('should include metadata in all tool responses', async () => {
       const result = await getEUBasis(db, { sfs_number: '2018:218' });
 
-      expect(result._metadata).toBeDefined();
-      expect(result._metadata.disclaimer).toContain('NOT LEGAL ADVICE');
-      expect(result._metadata.data_freshness).toBeDefined();
-      expect(result._metadata.source_authority).toBeDefined();
+      expect(result._meta).toBeDefined();
+      expect(result._meta.disclaimer).toContain('NOT LEGAL ADVICE');
+      expect(result._meta.data_freshness).toBeDefined();
+      expect(result._meta.source_authority).toBeDefined();
     });
   });
 

--- a/tests/tools/get-provision.test.ts
+++ b/tests/tools/get-provision.test.ts
@@ -148,6 +148,18 @@ describe('get_provision', () => {
     expect(prov.document_id).toBe('1998:204');
   });
 
+  it('should resolve document by colloquial name', async () => {
+    const response = await getProvision(db, {
+      document_id: 'dataskyddslagen',
+      provision_ref: '1:1',
+    });
+
+    expect(response.results).not.toBeNull();
+    const prov = response.results as Exclude<typeof response.results, null | Array<unknown>>;
+    expect(prov.document_id).toBe('2018:218');
+    expect(prov.provision_ref).toBe('1:1');
+  });
+
   it('should normalize Swedish provision_ref format', async () => {
     const response = await getProvision(db, {
       document_id: '2018:218',

--- a/tests/tools/search-case-law.test.ts
+++ b/tests/tools/search-case-law.test.ts
@@ -62,11 +62,11 @@ describe('search_case_law', () => {
     expect(response.results.length).toBeGreaterThan(0);
 
     for (const result of response.results) {
-      expect(result).toHaveProperty('_metadata');
-      expect(result._metadata).toHaveProperty('source');
-      expect(result._metadata).toHaveProperty('attribution');
-      expect(result._metadata.source).toBe('lagen.nu');
-      expect(result._metadata.attribution).toContain('CC-BY Domstolsverket');
+      expect(result).toHaveProperty('_meta');
+      expect(result._meta).toHaveProperty('source');
+      expect(result._meta).toHaveProperty('attribution');
+      expect(result._meta.source).toBe('lagen.nu');
+      expect(result._meta.attribution).toContain('CC-BY Domstolsverket');
     }
   });
 

--- a/tests/tools/search-legislation.test.ts
+++ b/tests/tools/search-legislation.test.ts
@@ -20,8 +20,8 @@ describe('search_legislation', () => {
     expect(response.results[0]).toHaveProperty('document_id');
     expect(response.results[0]).toHaveProperty('provision_ref');
     expect(response.results[0]).toHaveProperty('snippet');
-    expect(response._metadata).toHaveProperty('disclaimer');
-    expect(response._metadata).toHaveProperty('data_freshness');
+    expect(response._meta).toHaveProperty('disclaimer');
+    expect(response._meta).toHaveProperty('data_freshness');
   });
 
   it('should filter by document_id', async () => {


### PR DESCRIPTION
## Summary

- **`_metadata` → `_meta` rename** — All 44 occurrences across 18 files renamed to match the current gateway interaction standard. tsc clean, 275 tests pass. DB table names (`case_law_sync_metadata`, `db_metadata`) left unchanged.
- **Colloquial name aliases** — 20-entry `COLLOQUIAL_NAMES` map added to `resolveDocumentId()` as step 2.5 (between exact title and exact short_name). Resolves common names like "dataskyddslagen" → `2018:218`, "brottsbalken" → `1962:700`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 275 pass (17 pre-existing failures from empty local DB corpus)
- [x] `grep -rn '_metadata' src/ tests/ | grep -v case_law_sync_metadata | grep -v db_metadata` — zero hits
- [ ] After merge + Watchtower deploy: verify via gateway `get_provision(SE, dataskyddslagen, "1 kap. 1 §")` returns data with `_meta` field
- [ ] After deploy: update `swedish-law.json` manifest `response_shape` from `"legacy_metadata"` to `"current"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)