### PR TITLE
docs(readme): correct tool count (13→18) + statute count (2,415→6,041)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ Riksdagen API → Parse → SQLite → FTS5 snippet() → MCP response
 
 ---
 
-## Available Tools (13)
+## Available Tools (18)
+
+See [TOOLS.md](TOOLS.md) for full parameter schemas and the §tier-boundary section (free-tier vs premium-sensitive vs premium-only).
 
 ### Core Legal Research Tools (8)
 
@@ -153,10 +155,10 @@ Riksdagen API → Parse → SQLite → FTS5 snippet() → MCP response
 |------|-------------|
 | `search_legislation` | FTS5 search on 58,570 provisions with BM25 ranking |
 | `get_provision` | Retrieve specific provision by SFS + chapter/section |
-| `search_case_law` | FTS5 search on case law with court/date filters |
-| `get_preparatory_works` | Get linked propositions and SOUs for a statute |
+| `search_case_law` | FTS5 search on case law with court/date filters (premium-sensitive) |
+| `get_preparatory_works` | Get linked propositions and SOUs for a statute (premium-sensitive) |
 | `validate_citation` | Validate citation against database (zero-hallucination check) |
-| `build_legal_stance` | Aggregate citations from statutes, case law, prep works |
+| `build_legal_stance` | Aggregate citations from statutes, case law, prep works (premium-sensitive) |
 | `format_citation` | Format citations per Swedish conventions (full/short/pinpoint) |
 | `check_currency` | Check if statute is in force, amended, or repealed |
 
@@ -169,6 +171,21 @@ Riksdagen API → Parse → SQLite → FTS5 snippet() → MCP response
 | `search_eu_implementations` | Search EU documents with Swedish implementation counts |
 | `get_provision_eu_basis` | Get EU law references for specific provision |
 | `validate_eu_compliance` | Check implementation status (future, requires EU MCP) |
+
+### Versioning Tools (3, premium-only)
+
+| Tool | Description |
+|------|-------------|
+| `get_provision_history` | Provision version history showing amendments over time |
+| `diff_provision` | Diff two versions of a provision |
+| `get_recent_changes` | Recent statute changes within a time window |
+
+### Server Metadata Tools (2)
+
+| Tool | Description |
+|------|-------------|
+| `list_sources` | Data provenance metadata per source |
+| `about` | Server stats, freshness, build date, tier, dataset summary |
 
 ---
 
@@ -212,7 +229,7 @@ A [daily GitHub Actions workflow](.github/workflows/check-updates.yml) monitors 
 
 | Source | Check | Method |
 |--------|-------|--------|
-| **Statute amendments** | Riksdagen API date comparison | All 2,415 statutes checked |
+| **Statute amendments** | Riksdagen API date comparison | All 6,041 statutes checked |
 | **New statutes** | Riksdagen SFS publications (90-day window) | Diffed against database |
 | **Case law** | lagen.nu feed entry count | Compared to database |
 | **Preparatory works** | Riksdagen proposition API (30-day window) | New props detected |
@@ -332,7 +349,7 @@ This server is part of **Ansvar's Compliance Suite** -- MCP servers that work to
 **Query 49 EU regulations directly from Claude** -- GDPR, AI Act, DORA, NIS2, MiFID II, eIDAS, and more. Full regulatory text with article-level search. `npx @ansvar/eu-regulations-mcp`
 
 ### @ansvar/swedish-law-mcp (This Project)
-**Query 2,415 Swedish statutes directly from Claude** -- DSL, BrB, ABL, MB, and more. Full provision text with EU cross-references. `npx @ansvar/swedish-law-mcp`
+**Query 6,041 Swedish statutes directly from Claude** -- DSL, BrB, ABL, MB, and more. Full provision text with EU cross-references. `npx @ansvar/swedish-law-mcp`
 
 ### [@ansvar/us-regulations-mcp](https://github.com/Ansvar-Systems/US_Compliance_MCP)
 **Query US federal and state compliance laws** -- HIPAA, CCPA, SOX, GLBA, FERPA, and more. `npm install @ansvar/us-regulations-mcp`
@@ -383,7 +400,7 @@ If you use this MCP server in academic research:
   title = {Swedish Law MCP Server: Production-Grade Legal Research Tool},
   year = {2025},
   url = {https://github.com/Ansvar-Systems/swedish-law-mcp},
-  note = {Comprehensive Swedish legal database with 2,415 statutes and EU law cross-references}
+  note = {Comprehensive Swedish legal database with 6,041 statutes and EU law cross-references}
 }
 ```
 
@@ -405,7 +422,7 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 We build AI-accelerated compliance and legal research tools for the European market. This MCP server started as our internal reference tool for Swedish law -- turns out everyone building for the Swedish market has the same research frustrations.
 
-So we're open-sourcing it. Navigating 2,415 statutes shouldn't require a law degree.
+So we're open-sourcing it. Navigating 6,041 statutes shouldn't require a law degree.
 
 **[ansvar.eu](https://ansvar.eu)** -- Stockholm, Sweden
 


### PR DESCRIPTION
## Summary

Follow-up to PR #77 (golden-standard remediation). The README's tool inventory section was missed during that PR — `TOOLS.md`, `smithery.yaml`, and the source registry all moved to 18 tools, but `README.md` still said 13. This PR closes the drift.

## Changes

| Section | Before | After |
|---|---|---|
| `## Available Tools` heading | `(13)` | `(18)` |
| `### Core Legal Research Tools` | 8 tools, no tier annotation | 8 tools, premium-sensitive ones annotated |
| `### EU Law Integration Tools (5)` | unchanged | unchanged (already correct) |
| `### Versioning Tools (3, premium-only)` | missing | new section: `get_provision_history`, `diff_provision`, `get_recent_changes` |
| `### Server Metadata Tools (2)` | missing | new section: `list_sources`, `about` |
| Pointer to `TOOLS.md §tier-boundary` | missing | one-line reference at top of section |
| `2,415 statutes` references | 4 occurrences (line 215 freshness table, 335 footer pitch, 386 BibTeX note, 408 closing line) | all → `6,041` |

## Why this slipped through

I edited the early part of the README in PR #77 via targeted `Edit` calls on the "Use Remotely" section and the line 14 hero stat — never re-grepped the whole file for any other `2,415` or `tools (\d+)` references. A second-pass `grep -nE "\b(8\|13)\b.*tools?\|2,?415"` would have caught it.

## Test plan

- [x] `grep -nE "2,?415\|Available Tools \(13\)" README.md` returns no matches
- [x] All four surfaces now agree: README (18), TOOLS.md (18), smithery.yaml (18), src/tools/registry.ts (18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)