### PR TITLE
fix(attribution): emit Gate 13 _citation triple on every served item

### DIFF
--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -7,6 +7,7 @@ import { buildFtsQueryVariants } from '../utils/fts-query.js';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
 import { resolveDocumentId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
+import { buildSearchItemCitation, type CitationMetadata } from '../utils/citation.js';
 
 export interface SearchLegislationInput {
   query: string;
@@ -27,6 +28,12 @@ export interface SearchLegislationResult {
   relevance: number;
   valid_from?: string | null;
   valid_to?: string | null;
+  _citation: CitationMetadata;
+}
+
+interface SearchLegislationRow extends Omit<SearchLegislationResult, '_citation'> {
+  document_url: string | null;
+  document_short_name: string | null;
 }
 
 const DEFAULT_LIMIT = 10;
@@ -75,6 +82,8 @@ export async function searchLegislation(
         SELECT
           lpv.document_id,
           ld.title as document_title,
+          ld.url as document_url,
+          ld.short_name as document_short_name,
           lpv.provision_ref,
           lpv.chapter,
           lpv.section,
@@ -111,6 +120,8 @@ export async function searchLegislation(
       SELECT
         document_id,
         document_title,
+        document_url,
+        document_short_name,
         provision_ref,
         chapter,
         section,
@@ -129,6 +140,8 @@ export async function searchLegislation(
       SELECT
         lp.document_id,
         ld.title as document_title,
+        ld.url as document_url,
+        ld.short_name as document_short_name,
         lp.provision_ref,
         lp.chapter,
         lp.section,
@@ -158,9 +171,9 @@ export async function searchLegislation(
 
   params.push(fetchLimit);
 
-  const runQuery = (ftsQuery: string): SearchLegislationResult[] => {
+  const runQuery = (ftsQuery: string): SearchLegislationRow[] => {
     const bound = [ftsQuery, ...params];
-    return db.prepare(sql).all(...bound) as SearchLegislationResult[];
+    return db.prepare(sql).all(...bound) as SearchLegislationRow[];
   };
 
   const primaryResults = runQuery(queryVariants.primary);
@@ -191,12 +204,12 @@ export async function searchLegislation(
 }
 
 /**
- * Deduplicate search results by document_title + provision_ref.
- * Duplicate document IDs (numeric vs slug) cause the same provision to appear twice.
- * Keeps the first (highest-ranked) occurrence.
+ * Deduplicate search results by document_title + provision_ref and attach
+ * per-item `_citation`. Duplicate document IDs (numeric vs slug) cause the
+ * same provision to appear twice; we keep the first (highest-ranked) occurrence.
  */
 function deduplicateResults(
-  rows: SearchLegislationResult[],
+  rows: SearchLegislationRow[],
   limit: number,
 ): SearchLegislationResult[] {
   const seen = new Set<string>();
@@ -205,7 +218,17 @@ function deduplicateResults(
     const key = `${row.document_title}::${row.provision_ref}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    deduped.push(row);
+    const { document_url, document_short_name, ...rest } = row;
+    deduped.push({
+      ...rest,
+      _citation: buildSearchItemCitation(
+        row.document_id,
+        row.document_title,
+        row.provision_ref,
+        document_url,
+        document_short_name,
+      ),
+    });
     if (deduped.length >= limit) break;
   }
   return deduped;

--- a/src/utils/citation.ts
+++ b/src/utils/citation.ts
@@ -1,22 +1,56 @@
 /**
- * Citation metadata for the deterministic citation pipeline.
+ * Citation metadata — combines two contracts:
  *
- * Provides structured identifiers (canonical_ref, display_text, aliases)
- * that the platform's entity linker uses to match references in agent
- * responses to MCP tool results — without relying on LLM formatting.
+ * 1. Deterministic citation pipeline (canonical_ref / display_text / aliases /
+ *    lookup) used by the platform's entity linker.
+ * 2. Source Attribution Airtight standard (publisher / license / source_url),
+ *    enforced at gateway egress per the spec at
+ *    docs/superpowers/specs/2026-05-02-source-attribution-airtight-design.md.
+ *
+ * The attribution triple is load-bearing: items missing any of the three
+ * fields are dropped by `check_item_attribution` at the gateway.
  *
  * See: docs/guides/law-mcp-golden-standard.md Section 4.9c
  */
+
+/**
+ * Manifest-aligned attribution constants.
+ *
+ * MUST match `attribution.publisher` and `attribution.license` in
+ * backstage/catalog/fleet-manifests/swedish-law.json — gateway egress
+ * compares with strict equality.
+ */
+export const ATTRIBUTION_PUBLISHER = 'riksdagen.se';
+export const ATTRIBUTION_LICENSE = 'Public-Domain';
 
 export interface CitationMetadata {
   canonical_ref: string;
   display_text: string;
   aliases?: string[];
-  source_url?: string;
+  source_url: string;
+  publisher: string;
+  license: string;
   lookup: {
     tool: string;
     args: Record<string, string>;
   };
+}
+
+/**
+ * Resolve the source URL for a Swedish statute, falling back to the canonical
+ * Riksdagen URL pattern when the document row has no stored URL. Same pattern
+ * as the ingest script's fallback (`scripts/ingest-riksdagen.ts`).
+ */
+export function resolveRiksdagenSourceUrl(
+  documentId: string,
+  dbUrl: string | null | undefined,
+): string {
+  if (dbUrl && dbUrl.trim().length > 0) return dbUrl;
+  if (/^\d{4}:\d+$/.test(documentId)) {
+    return `https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/sfs-${documentId.replace(':', '-')}`;
+  }
+  // Non-SFS identifiers (case law, bills) — fall back to the document search.
+  return `https://www.riksdagen.se/sv/dokument-och-lagar/?docid=${encodeURIComponent(documentId)}`;
 }
 
 /**
@@ -27,7 +61,7 @@ export interface CitationMetadata {
  * @param provisionRef   Provision reference (e.g., "34" or "3:12")
  * @param inputDocId     The document_id argument as passed by the caller (e.g., "sfs-2018-218")
  * @param inputSection   The section argument as passed by the caller (e.g., "art-34")
- * @param sourceUrl      Official portal URL for this law (optional)
+ * @param sourceUrl      Official portal URL for this law (optional — fallback is constructed if missing)
  * @param shortName      Short name / alias (e.g., "DSL") (optional)
  */
 export function buildProvisionCitation(
@@ -39,32 +73,52 @@ export function buildProvisionCitation(
   sourceUrl?: string | null,
   shortName?: string | null,
 ): CitationMetadata {
-  // Build canonical_ref from the SFS number format
-  // DB id "2018:218" -> "SFS 2018:218" (Swedish statute format)
   const canonicalRef = documentId.match(/^\d{4}:\d+$/)
     ? `SFS ${documentId}`
     : documentTitle;
 
-  // Build display_text
   const sectionLabel = provisionRef.includes(':')
     ? `${provisionRef.split(':')[0]} kap. ${provisionRef.split(':')[1]} §`
     : `${provisionRef} §`;
   const displayText = `${sectionLabel} ${canonicalRef}`;
 
-  // Build aliases from document title and short name
   const aliases: string[] = [];
   if (shortName) aliases.push(shortName);
-  // Add the raw document_id as an alias (matches argument-derived patterns)
   if (documentId !== canonicalRef) aliases.push(documentId);
 
   return {
     canonical_ref: canonicalRef,
     display_text: displayText,
     ...(aliases.length > 0 && { aliases }),
-    ...(sourceUrl && { source_url: sourceUrl }),
+    source_url: resolveRiksdagenSourceUrl(documentId, sourceUrl),
+    publisher: ATTRIBUTION_PUBLISHER,
+    license: ATTRIBUTION_LICENSE,
     lookup: {
       tool: 'get_provision',
       args: { document_id: inputDocId, section: inputSection },
     },
   };
+}
+
+/**
+ * Build citation metadata for a single search_legislation result item.
+ * Search items always carry `_citation` so the gateway egress filter
+ * (check_item_attribution) accepts them.
+ */
+export function buildSearchItemCitation(
+  documentId: string,
+  documentTitle: string,
+  provisionRef: string,
+  sourceUrl?: string | null,
+  shortName?: string | null,
+): CitationMetadata {
+  return buildProvisionCitation(
+    documentId,
+    documentTitle,
+    provisionRef,
+    documentId,
+    provisionRef,
+    sourceUrl,
+    shortName,
+  );
 }

--- a/tests/citation/attribution-emit.test.ts
+++ b/tests/citation/attribution-emit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Attribution emit (Gate 13) — verifies every customer-visible item carries
+ * the source-attribution triple {source_url, publisher, license} per the
+ * Source Attribution Airtight spec (2026-05-02).
+ *
+ * The gateway's `check_item_attribution` filter drops items missing any of
+ * these fields, so this test is the unit-level guard against regression.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Database } from '@ansvar/mcp-sqlite';
+import { getProvision } from '../../src/tools/get-provision.js';
+import { searchLegislation } from '../../src/tools/search-legislation.js';
+import { createTestDatabase, closeTestDatabase } from '../fixtures/test-db.js';
+
+// Manifest contract — keep in sync with backstage/catalog/fleet-manifests/swedish-law.json
+const EXPECTED_PUBLISHER = 'riksdagen.se';
+const EXPECTED_LICENSE = 'Public-Domain';
+const SOURCE_URL_PATTERN = /^https?:\/\/(?:www\.|data\.)?riksdagen\.se\/.+/;
+
+describe('attribution emit — get_provision', () => {
+  let db: Database;
+  beforeAll(() => { db = createTestDatabase(); });
+  afterAll(() => { closeTestDatabase(db); });
+
+  it('emits _citation with publisher, license, and matching source_url', async () => {
+    const response = await getProvision(db, {
+      document_id: '2018:218',
+      provision_ref: '1:1',
+    });
+
+    expect(response._citation).toBeDefined();
+    expect(response._citation!.publisher).toBe(EXPECTED_PUBLISHER);
+    expect(response._citation!.license).toBe(EXPECTED_LICENSE);
+    expect(response._citation!.source_url).toMatch(SOURCE_URL_PATTERN);
+  });
+
+  it('emits a fallback source_url when document.url is null', async () => {
+    // 1998:204 (PUL) has url=null in the test fixture — common in production too
+    const response = await getProvision(db, {
+      document_id: '1998:204',
+      provision_ref: '5 a',
+    });
+
+    expect(response._citation).toBeDefined();
+    expect(response._citation!.publisher).toBe(EXPECTED_PUBLISHER);
+    expect(response._citation!.license).toBe(EXPECTED_LICENSE);
+    // Fallback must still be a valid riksdagen.se URL pinning the SFS number
+    expect(response._citation!.source_url).toMatch(SOURCE_URL_PATTERN);
+    expect(response._citation!.source_url).toContain('1998-204');
+  });
+});
+
+describe('attribution emit — search_legislation (per-item)', () => {
+  let db: Database;
+  beforeAll(() => { db = createTestDatabase(); });
+  afterAll(() => { closeTestDatabase(db); });
+
+  it('emits _citation on every result item', async () => {
+    const response = await searchLegislation(db, { query: 'personuppgifter' });
+
+    expect(response.results.length).toBeGreaterThan(0);
+    for (const item of response.results) {
+      expect(item._citation).toBeDefined();
+      expect(item._citation!.publisher).toBe(EXPECTED_PUBLISHER);
+      expect(item._citation!.license).toBe(EXPECTED_LICENSE);
+      expect(item._citation!.source_url).toMatch(SOURCE_URL_PATTERN);
+    }
+  });
+
+  it('per-item _citation references the originating document', async () => {
+    const response = await searchLegislation(db, {
+      query: 'personuppgifter',
+      document_id: '2018:218',
+    });
+
+    expect(response.results.length).toBeGreaterThan(0);
+    for (const item of response.results) {
+      // canonical_ref should encode SFS 2018:218 for items from that document
+      expect(item._citation!.canonical_ref).toBe('SFS 2018:218');
+      expect(item._citation!.lookup.tool).toBe('get_provision');
+      expect(item._citation!.lookup.args.document_id).toBe('2018:218');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the Gate 13 attribution-emit gap that surfaced during testing of #78. Three sub-bugs, one root cause:

1. `search_legislation` items had no `_citation` block — the gateway's `check_item_attribution` egress filter (Source Attribution Airtight spec, 2026-05-02) drops them.
2. `get_provision._citation` lacked `publisher` and `license` — the `CitationMetadata` interface predated the airtight standard.
3. Emitted `source_url` was `www.riksdagen.se`; manifest pattern only accepted `data.riksdagen.se`.

Root cause: `CitationMetadata` was built for the entity-linker pipeline (canonical_ref / aliases / lookup) and had no slots for the load-bearing attribution triple (`publisher`, `license`, `source_url`).

## Changes

- `src/utils/citation.ts`: `CitationMetadata` now requires `source_url`, `publisher`, `license`. New `ATTRIBUTION_PUBLISHER` / `ATTRIBUTION_LICENSE` constants align with the manifest. New `resolveRiksdagenSourceUrl` helper constructs an SFS-format fallback URL when `legal_documents.url` is null. New `buildSearchItemCitation` for per-item search citations.
- `src/tools/search-legislation.ts`: SQL now selects `ld.url` + `ld.short_name`; `deduplicateResults` attaches per-item `_citation` to every result.
- `tests/citation/attribution-emit.test.ts`: 4 new unit tests covering the emit triple on both surfaces, including the null-URL fallback.

## Coordination

Manifest update on `Ansvar-Architecture-Documentation` branch `fix/swedish-law-attribution-emit-2026-05-06` ships the matching publisher (`riksdagen.se`) and pattern (`(?:www\.|data\.)?`). Both must land before Gate 13 enforcement (compliance_deadline 2026-06-01).

## Test plan

- [x] 4 new unit tests pass (`tests/citation/attribution-emit.test.ts`)
- [x] No regressions: 280/297 unit tests pass (17 pre-existing contract failures unchanged on baseline)
- [x] `tsc --noEmit` clean
- [ ] Live verification on dev after merge: `get_provision` and `search_legislation` responses contain the triple
- [ ] Source-legitimacy audit re-runs clean for `swedish-law` once both PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)