### PR TITLE
chore: sync license to SE-Statutory-PD per arch-docs 2026-05-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,9 +410,9 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Statutes & Propositions:** Swedish Government (public domain)
-- **Case Law:** CC-BY Domstolsverket (via lagen.nu)
-- **EU Metadata:** EUR-Lex (EU public domain)
+- **Statutes & Propositions:** `SE-Statutory-PD` -- Swedish statutory public domain. Upphovsrättslagen (1960:729) §9 excludes författningar (laws and regulations), beslut av myndighet (decisions of public authorities), yttranden av svensk myndighet (official statements), and official translations of these works from copyright protection. Verified verbatim 2026-05-17 -- see [`docs/audits/2026-05-17-eu-copyright-statutory-works-batch-3-BG-HR-SK-SI-SE.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/audits/2026-05-17-eu-copyright-statutory-works-batch-3-BG-HR-SK-SI-SE.md). Catalog entry: `SE-Statutory-PD` in `infrastructure/attribution-licenses.json`.
+- **Case Law:** CC-BY Domstolsverket (via lagen.nu) -- court decisions also covered by Upphovsrättslagen §9, with Domstolsverket compilation under CC-BY
+- **EU Metadata:** EUR-Lex (EU public domain, Decision 2011/833/EU)
 
 ---
 

--- a/sources.yml
+++ b/sources.yml
@@ -1,5 +1,13 @@
 # sources.yml — Data provenance metadata
 # Reference: docs/mcp-infrastructure-blueprint.md §3
+# License axis: SE-Statutory-PD (Swedish statutory public domain)
+# Statutory basis: Upphovsrättslagen (1960:729) §9 — författningar (laws and
+# regulations), beslut av myndighet (decisions of public authorities),
+# yttranden av svensk myndighet (official statements of Swedish authorities),
+# and official translations of these works enjoy no copyright protection.
+# Verified verbatim 2026-05-17.
+# Cross-ref: docs/audits/2026-05-17-eu-copyright-statutory-works-batch-3-BG-HR-SK-SI-SE.md
+# Catalog entry: infrastructure/attribution-licenses.json → "SE-Statutory-PD"
 
 schema_version: "1.0"
 mcp_name: "Swedish Law MCP"
@@ -16,9 +24,9 @@ sources:
     last_ingested: "2026-02-15"
     last_verified: "2026-05-09"
     license_or_terms:
-      type: "Government Open Data (Swedish PSI)"
-      url: "https://data.riksdagen.se/"
-      summary: "Swedish public sector information, free to reuse under PSI regulations"
+      type: "SE-Statutory-PD"
+      url: "https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/lag-1960729-om-upphovsratt-till-litterara-och_sfs-1960-729"
+      summary: "Swedish statutory public domain (Upphovsrättslagen 1960:729 §9). Författningar (laws and regulations), beslut av myndighet (decisions of public authorities), yttranden av svensk myndighet (official statements), and official translations enjoy no copyright protection. Statute-level basis on the underlying text; Riksdagen Open Data compilation is additionally redistributable under Swedish PSI regulations."
     coverage:
       scope: "All consolidated Swedish statutes (SFS), including chapters, sections, and provision text"
       limitations: "May lag official publication by 24-48 hours; no editorial annotations or commentary"


### PR DESCRIPTION
## Summary

Replace generic license declaration with the jurisdiction-specific statutory-PD code that landed in arch-docs catalog today.

- `sources.yml` license type updated to `SE-Statutory-PD`
- README data-licenses block points at the statutory section and the new catalog entry

## Statutory basis

Upphovsrättslagen (1960:729) §9 — författningar, beslut av myndighet, yttranden av svensk myndighet, and official translations excluded from copyright protection. Verified verbatim 2026-05-17.

## Scope

License-axis sync only. No corpus content, ingestion code, or runtime behaviour changes.

## Cross-references

- `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-3-BG-HR-SK-SI-SE.md` (arch-docs)
- `infrastructure/attribution-licenses.json` → `SE-Statutory-PD` (arch-docs)

## Test plan

- [ ] CI green (7 workflows + tests)
- [ ] No diff in `data/` or `src/` (license-axis only)