### PR TITLE
fix(http-server): close session race causing ClosedResourceError under sequential calls

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -104,8 +104,22 @@ async function main() {
         }
 
         if (req.method === 'POST') {
-          const transport = new StreamableHTTPServerTransport({
+          // Register the transport in the sessions map AS SOON AS the
+          // session_id is minted (via onsessioninitialized) — not after
+          // handleRequest returns. handleRequest is async and yields to
+          // the event loop while processing initialize; if the client's
+          // next call arrives before the post-await session set runs,
+          // the lookup above falls through to this branch and creates a
+          // competing transport, whose onclose then fires and the first
+          // call sees ClosedResourceError on its next message. Symptom:
+          // "SessionStale/ClosedResourceError under sequential calls"
+          // (risk_assessment workflow smoke test, 2026-05-17).
+          let transport: StreamableHTTPServerTransport;
+          transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: (sessionId: string) => {
+              sessions.set(sessionId, transport);
+            },
           });
           const server = createMCPServer();
           await server.connect(transport);
@@ -113,7 +127,6 @@ async function main() {
             if (transport.sessionId) sessions.delete(transport.sessionId);
           };
           await transport.handleRequest(req, res);
-          if (transport.sessionId) sessions.set(transport.sessionId, transport);
           return;
         }
 


### PR DESCRIPTION
## Summary

Closes Bug #4 from the 2026-05-17 risk_assessment workflow smoke test: "Swedish Law MCP Timeout → SessionStale/ClosedResourceError under sequential calls."

**Root cause:** the transport was registered in the sessions map AFTER \`transport.handleRequest()\` returned. But \`handleRequest\` is async and yields to the event loop while processing the initialize message; if the gateway's NEXT MCP call arrived before the post-await \`sessions.set\` executed, the session lookup missed and a competing transport was created. The first transport's \`onclose\` then fired (when the second request finished) and the first call saw \`ClosedResourceError\` on its next message.

**Fix:** register the transport via the SDK's \`onsessioninitialized\` callback. The callback fires synchronously when sessionId is minted, before \`handleRequest\` can yield. No race window between session-id generation and sessions-map insertion.

## Why this surfaced now

The risk_assessment workflow runs 5 enrichment passes per risk through the gateway. For a 2-risk smoke test that's 10 sequential MCP calls in quick succession against the same session — exactly the workload that triggers the race.

## Test plan

- [x] \`npm test\` — 232 passed, 70 skipped (no regression).
- [x] \`npx tsc --noEmit\` — clean.
- [ ] Post-merge: re-run the risk_assessment smoke test through the gateway with \`jurisdictions=["SE"]\` and verify no \`ClosedResourceError\` events.

## Fleet follow-up

100 of 101 law-MCP repos use the same pre-fix pattern. A separate batch sweep via \`apply-mcp-standard.py\` should propagate this fix fleet-wide. Out of scope for this PR.

## Companion PR

[ansvar-workflow-mcp#66](https://github.com/Ansvar-Systems/ansvar-workflow-mcp/pull/66) closes bugs #1-3, #5-7 from the same smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)