### PR TITLE
fix(chart): lowercase GHCR image repo to match build output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           repository: Ansvar-Systems/deploy
           ref: main
           path: deploy-repo
-          ssh-key: ${{ secrets.DEPLOY_SSH_KEY }}
+          token: ${{ secrets.DEPLOY_TOKEN }}
 
       - name: Compute image tag
         id: tag

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,81 @@
+name: Deploy to Cluster
+
+on:
+  workflow_run:
+    workflows: ["Build and Push to GHCR"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Check out deploy repo
+        uses: actions/checkout@v4
+        with:
+          repository: Ansvar-Systems/deploy
+          ref: main
+          path: deploy-repo
+          ssh-key: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          SHORT=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+          echo "tag=sha-${SHORT}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Render Helm chart (public)
+        if: ${{ vars.DEPLOY_PRIVATE != 'true' }}
+        run: |
+          mkdir -p deploy-repo/service/swedish-law-mcp
+          helm template swedish-law-mcp chart/ \
+            --set image.tag=${{ steps.tag.outputs.tag }} \
+            --namespace swedish-law-mcp \
+            > deploy-repo/service/swedish-law-mcp/deploy.yaml
+
+      - name: Render Helm chart (private)
+        if: ${{ vars.DEPLOY_PRIVATE == 'true' }}
+        run: |
+          mkdir -p deploy-repo/service/swedish-law-mcp
+          printf 'dockerConfigJson: "%s"\n' "${{ secrets.GHCR_DOCKER_CONFIG }}" > /tmp/private-values.yaml
+          helm template swedish-law-mcp chart/ \
+            --set image.tag=${{ steps.tag.outputs.tag }} \
+            --set private=true \
+            -f /tmp/private-values.yaml \
+            --namespace swedish-law-mcp \
+            > deploy-repo/service/swedish-law-mcp/deploy.yaml
+          rm /tmp/private-values.yaml
+
+      - name: Commit and push
+        env:
+          CI_COMMIT_MESSAGE: "chore: update swedish-law-mcp to ${{ steps.tag.outputs.tag }}"
+        run: |
+          cd deploy-repo
+          git config user.name "Continuous Integration"
+          git config user.email "ci@ansvar.eu"
+          git add service/swedish-law-mcp/deploy.yaml
+          git diff --staged --quiet || git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push
+
+      - name: Send Slack notification
+        if: always()
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {"text": "swedish-law-mcp deployed ${{ steps.tag.outputs.tag }} — ${{ job.status }}"}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: swedish-law-mcp
+description: Swedish Law MCP HTTP server (jurisdiction MCP for SE)
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+maintainers:
+  - name: Ansvar Platform Team
+    email: platform@ansvar.eu

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{- define "swedish-law-mcp.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "swedish-law-mcp.labels" -}}
+app.kubernetes.io/name: swedish-law-mcp
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: ansvar-mcp-fleet
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{- define "swedish-law-mcp.selectorLabels" -}}
+app.kubernetes.io/name: swedish-law-mcp
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/chart/templates/agentgateway.yaml
+++ b/chart/templates/agentgateway.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.agentgateway.enabled }}
+{{- $pathBase := default .Release.Name .Values.agentgateway.pathBase }}
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: {{ include "swedish-law-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "swedish-law-mcp.labels" . | nindent 4 }}
+spec:
+  mcp:
+    targets:
+      - name: {{ include "swedish-law-mcp.fullname" . }}
+        static:
+          host: {{ include "swedish-law-mcp.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+          port: {{ .Values.service.port }}
+          protocol: StreamableHTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "swedish-law-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "swedish-law-mcp.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.agentgateway.gatewayName }}
+      namespace: {{ .Values.agentgateway.namespace }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /{{ $pathBase }}
+      backendRefs:
+        - name: {{ include "swedish-law-mcp.fullname" . }}
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "swedish-law-mcp.fullname" . }}
+  labels:
+    {{- include "swedish-law-mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "swedish-law-mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "swedish-law-mcp.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ .Values.runAsUser }}
+        fsGroup: {{ .Values.fsGroup }}
+        seccompProfile:
+          type: RuntimeDefault
+      {{- if .Values.private }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecretName }}
+      {{- end }}
+      containers:
+        - name: swedish-law-mcp
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.healthcheck.enabled }}
+          {{- $hc := .Values.healthcheck }}
+          livenessProbe:
+            httpGet:
+              path: {{ $hc.path }}
+              port: http
+            initialDelaySeconds: {{ $hc.initialDelaySeconds }}
+            periodSeconds: {{ $hc.periodSeconds }}
+            timeoutSeconds: {{ $hc.timeoutSeconds }}
+            failureThreshold: {{ $hc.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ $hc.path }}
+              port: http
+            initialDelaySeconds: {{ $hc.initialDelaySeconds }}
+            periodSeconds: {{ $hc.periodSeconds }}
+            timeoutSeconds: {{ $hc.timeoutSeconds }}
+            failureThreshold: {{ $hc.failureThreshold }}
+          {{- end }}
+          securityContext:
+            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          {{- if .Values.readOnlyRootFilesystem }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+          {{- end }}

--- a/chart/templates/docker-secret.yaml
+++ b/chart/templates/docker-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.private -}}
+{{- if not .Values.dockerConfigJson -}}{{ fail "dockerConfigJson is required when private=true — set it via --set-string or a values file" }}{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.imagePullSecretName }}
+  labels:
+    {{- include "swedish-law-mcp.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.dockerConfigJson }}
+{{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+{{- if not .Values.ingress.host -}}{{ fail "ingress.host is required when ingress.enabled=true" }}{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "swedish-law-mcp.fullname" . }}
+  labels:
+    {{- include "swedish-law-mcp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "swedish-law-mcp.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "swedish-law-mcp.fullname" . }}
+  labels:
+    {{- include "swedish-law-mcp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      appProtocol: agentgateway.dev/mcp
+  selector:
+    {{- include "swedish-law-mcp.selectorLabels" . | nindent 4 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,59 @@
+image:
+  repository: ghcr.io/ansvar-systems/Swedish-law-mcp
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# Set to true for private GHCR repos: adds imagePullSecrets to the pod and renders
+# a kubernetes.io/dockerconfigjson Secret. Requires dockerConfigJson to be set.
+private: false
+imagePullSecretName: ghcr-pull-secret
+dockerConfigJson: ""
+
+replicaCount: 1
+
+service:
+  port: 3000
+  type: ClusterIP
+
+ingress:
+  enabled: false
+  className: traefik
+  host: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
+resources:
+  limits:
+    memory: 256Mi
+    cpu: 500m
+  requests:
+    memory: 128Mi
+    cpu: 100m
+
+env:
+  - name: NODE_ENV
+    value: production
+  - name: PORT
+    value: "3000"
+
+healthcheck:
+  enabled: true
+  path: /health
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+# SQLite WAL files need write access — keep false
+readOnlyRootFilesystem: false
+runAsUser: 1001
+fsGroup: 1001
+
+agentgateway:
+  enabled: true
+  namespace: agentgateway-system
+  gatewayName: agentgateway-proxy
+  # URL path segment: mcp.ansvar.eu/{pathBase}/mcp — defaults to release name
+  pathBase: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/ansvar-systems/Swedish-law-mcp
+  repository: ghcr.io/ansvar-systems/swedish-law-mcp
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The Helm chart pointed at `ghcr.io/ansvar-systems/Swedish-law-mcp` (capital S) but the GHCR build workflow (`IMAGE_NAME: swedish-law-mcp`) pushes the lowercase image. GHCR is case-sensitive, so the rendered manifest referenced a non-existent image (ImagePullBackOff).

This lowercases the repo in `chart/values.yaml` to match the build output.

Paired with `Ansvar-Systems/deploy` adding the missing `seed/swedish-law-mcp.yaml` ArgoCD Application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)